### PR TITLE
deploy binary on emulated raspberry pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Doge Home
+
+A 100% secure smart home writen in rust for the raspberry pi
+
+# Emulate the raspberi pi 1
+
+Dockerpi emulate a raspberypi in a docker using qemu
+
+```bash
+sudo docker run -it -p 5022:5022 -v $HOME/.dockerpi:/sdcard lukechilds/dockerpi
+```
+
+It will create an image for the raspberry pi and launch this image.
+ssh is not active by default. in order to activate ssh, login into the raspberry pi:
+
+```bash
+login: pi
+password: raspberry
+```
+
+go to `/etc/ssh/sshd_config` and uncomment the following lines:
+
+```bash
+#Port 22
+#AddressFamily any
+#ListenAddress 0.0.0.0
+#ListenAddress ::
+```
+
+then
+
+```bash
+systemctl enable ssh
+systemctl start ssh
+```
+
+in this way you can connect to your emulated raspberrypi
+
+```bash
+ssh -p 5022 pi@localhost
+```
+
+# cross compiling rust for the raspberry pi
+
+cross compilation is done using cross:
+<https://github.com/rust-embedded/cross>
+
+to install cross, execute:
+```bash 
+cargo install cross
+```
+
+the `deploy.sh` script compile, deploy, and execute the binary on the targeted raspberry pi. If ssh does not work, check if you dockerpi is running.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A 100% secure smart home writen in rust for the raspberry pi
 
-# Emulate the raspberi pi 1
+## Emulate the raspberi pi 1
 
 Dockerpi emulate a raspberypi in a docker using qemu
 
@@ -18,7 +18,7 @@ login: pi
 password: raspberry
 ```
 
-go to `/etc/ssh/sshd_config` and uncomment the following lines:
+Go to `/etc/ssh/sshd_config` and uncomment the following lines:
 
 ```bash
 #Port 22
@@ -34,20 +34,21 @@ systemctl enable ssh
 systemctl start ssh
 ```
 
-in this way you can connect to your emulated raspberrypi
+This way you can connect to your emulated raspberrypi:
 
 ```bash
 ssh -p 5022 pi@localhost
 ```
 
-# cross compiling rust for the raspberry pi
+## cross compiling rust for the raspberry pi
 
-cross compilation is done using cross:
+Raspberrypi 0/1 use arm and 2/3 use armv7. In order to compile your code from your x86/x64 machine, you need to use specific tools.
+Cross compilation is done using cross:
 <https://github.com/rust-embedded/cross>
 
-to install cross, execute:
+To install cross, execute:
 ```bash 
 cargo install cross
 ```
 
-the `deploy.sh` script compile, deploy, and execute the binary on the targeted raspberry pi. If ssh does not work, check if you dockerpi is running.
+The `deploy.sh` script compile, deploy, and execute the binary on the targeted raspberry pi. You must add your user to the docker group in order to compile with cross. If ssh does not work, check if you dockerpi is running.

--- a/crossbuild/Dockerfile
+++ b/crossbuild/Dockerfile
@@ -1,0 +1,11 @@
+# from https://capnfabs.net/posts/cross-compiling-rust-apps-raspberry-pi/
+# not used now, will be useful when external library will be needed in cross compilation
+
+# Use the container that comes with `cross` as a base. It's already got
+# a cross-compile toolchain installed, so that's less work for us.
+FROM rustembedded/cross:armv7-unknown-linux-gnueabihf-0.2.1
+
+RUN apt-get update
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install --assume-yes libssl-dev:armhf libasound2-dev:armhf

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,16 @@
+# inspired by https://chacin.dev/blog/cross-compiling-rust-for-the-raspberry-pi/
+
+PI_IP=localhost # Be sure to change this!
+#TARGET=armv7-unknown-linux-gnueabihf # Pi 2/3/4
+TARGET=arm-unknown-linux-gnueabihf # Pi 0/1
+PORT=5022
+EXEC=doge-home
+
+echo "build binary"
+cross build --target $TARGET
+
+echo "upload binary"
+sshpass -p 'raspberry' scp -P $PORT -r ./target/$TARGET/debug/$EXEC pi@$PI_IP:/home/pi
+
+echo "execute binary"
+sshpass -p 'raspberry' ssh -p $PORT pi@$PI_IP "./$EXEC"


### PR DESCRIPTION
In response to this issue: <https://github.com/BajacDev/doge-home/issues/4#issue-868837044>

This PR contains a script that compile, deploy, and execute a binary on a raspberry pi.
`README.md` contains instructions in order to create a docker container simulating a raspberry pi (the default one is raspberry pi 1)