### PR TITLE
add fuzzing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Cargo.lock
 .vscode
 TODO.txt
+*.proptest-regressions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ path = "src/lib.rs"
 [dependencies]
 libc = "0.2"
 
+[dev-dependencies]
+proptest = "1.0.0"
+
 # klee dependencies
 
 [dependencies.klee-sys]

--- a/README.md
+++ b/README.md
@@ -61,18 +61,23 @@ The `deploy.sh` script compile, deploy, and execute the binary on the targeted r
 
 ### Unit test
 
+Tests can be found in `tests/`
+
+use
 `cargo test --tests` 
 Nothing is tested yet.
 
 ### klee tests
 
+Klee tests can be found in `examples/`
+
 To simplify klee installation, we will use the `rust-klee-docker`: <https://github.com/BajacDev/rust-klee-docker>
 
 ```
-docker run --rm -it -v /path/to/doge-home:/home/arch/doge-home rkd
+docker run --rm -it -v /host/path/to/doge-home:/home/ubuntu/doge-home rkd
 ```
 
-then, in the conatainer:
+then, in the container:
 
 ```
 cd doge-home

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,3 @@ pub mod bindings;
 pub mod devices;
 pub mod event;
 pub mod smarthome;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/tests/proptest_example.rs
+++ b/tests/proptest_example.rs
@@ -1,0 +1,10 @@
+use proptest::prelude::*;
+
+proptest! {
+  #[test]
+  fn test_add(a in 0..1000i32, b in 0..1000i32) {
+    let sum = a + b;
+    assert!(sum >= b);
+    assert!(sum >= a);
+  }
+}

--- a/tests/test_example.rs
+++ b/tests/test_example.rs
@@ -1,0 +1,10 @@
+// use this to test doge home
+extern crate doge_home;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert_eq!(2 + 2, 4);
+    }
+}


### PR DESCRIPTION
Add fuzzing to the repo for future use

`Proptest` is a fuzzing library with an easy syntax. It is based on `Hypotesis`. 
difference between proptest and quickeck: <https://altsysrq.github.io/proptest-book/proptest/vs-quickcheck.html>
tldr: Proptest is the best rust fuzzing library out there. 